### PR TITLE
Moved return $node outside loop

### DIFF
--- a/sizlate.js
+++ b/sizlate.js
@@ -31,8 +31,8 @@ var updateNodeWithObject = function($node, obj) {
 			default: 
 				$node.attr(key, obj[key]);
 		}
-		return $node;
 	}
+	return $node;
 };
 var updateNode = function($node, selector, data) {
 	switch(typeof data) {


### PR DESCRIPTION
There was an issue where I was passing multiple data-attributes to a node, however only the first was returning.  Turns out the return $node was inside the for loop so only ever done once.
