### PR TITLE
Added innerText method to set cheerio.text()...

### DIFF
--- a/sizlate.js
+++ b/sizlate.js
@@ -28,6 +28,9 @@ var updateNodeWithObject = function($node, obj) {
 			case'innerHTML' :
 				$node.html(obj[key]);
 			break;
+			case'innerText' :
+				$node.text(obj[key]);
+			break;
 			default: 
 				$node.attr(key, obj[key]);
 		}


### PR DESCRIPTION
So that we needn't rely on using cheerio.html(). This means that fields that definitely shouldn't contain HTML can be cleanly escaped by cheerio and closes some potential XSS attack vectors.

The change seems to make sense from a security perspective and doesn't change any APIs.
